### PR TITLE
fix a hard coded path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,7 @@ system = node['kernel']['machine'] == 'x86_64' ? 'win64' : 'win32'
 
 batch 'copy_nssm' do
   code <<-EOH
-    xcopy c:\\chef\\cache\\#{basename}\\#{system}\\nssm.exe %WINDIR% /y
+    xcopy #{Chef::Config[:file_cache_path].gsub("/","\\")}\\#{basename}\\#{system}\\nssm.exe %WINDIR% /y
   EOH
   not_if { ::File.exist?('c:\\windows\\nssm.exe') }
 end


### PR DESCRIPTION
fixes a hard coded path to the chef cache dir.  had to replace "/" with "\" since xcopy didn't seem to like a leading "/" and the mix of "/" and "\".
