### PR TITLE
Add an attribute for the install location of nssm.exe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,4 @@
 default['nssm']['src'] = 'http://nssm.cc/release/nssm-2.24.zip'
 default['nssm']['sha256'] = '727d1e42275c605e0f04aba98095c38a8e1e46def453cdffce42869428aa6743'
+
+default['nssm']['install_location'] = '%WINDIR%'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,7 @@ if platform?('windows')
 
   batch 'copy_nssm' do
     code <<-EOH
-      xcopy #{Chef::Config[:file_cache_path].gsub('/', '\\')}\\#{basename}\\#{system}\\nssm.exe %WINDIR% /y
+      xcopy #{Chef::Config[:file_cache_path].gsub('/', '\\')}\\#{basename}\\#{system}\\nssm.exe "#{node['nssm']['install_location']}" /y
     EOH
     not_if { ::File.exist?('c:\\windows\\nssm.exe') }
   end

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -15,7 +15,7 @@ describe 'nssm::default' do
 
     it 'copies nssm executable' do
       expect(chef_run).to run_batch('copy_nssm').with(
-          code: /xcopy .*\\nssm-2.24\\win64\\nssm.exe %WINDIR% \/y/)
+          code: /xcopy .*\\nssm-2.24\\win64\\nssm.exe "%WINDIR%" \/y/)
     end
   end
 

--- a/spec/unit/install_location_spec.rb
+++ b/spec/unit/install_location_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'nssm::default' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2') do |node|
+      node.set['nssm']['install_location'] = 'c:\somewhere'
+    end.converge(described_recipe)
+  end
+
+  it 'copies nssm executable' do
+    expect(chef_run).to run_batch('copy_nssm').with(
+        code: /xcopy .*\\nssm-2.24\\win64\\nssm.exe "c:\\somewhere" \/y/)
+  end
+end


### PR DESCRIPTION
I've added an attribute for the install location of the nssm.exe file so that it's not hard-coded to install in %WINDIR%. The default is still set to %WINDIR%