### PR TITLE
Use new install_location attribute everywhere

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,11 @@
+# Provides some methods to ease interaction with Nssm
+module Nssm
+  def self.installed?(install_path)
+    # check if the binary file exists - need to evaluate environment variable
+    ::File.exist? binary_path(install_path).gsub(/%[^%]+%/) { |m| ENV[m[1..-2]] }
+  end
+
+  def self.binary_path(install_path)
+    install_path.end_with?('.exe') ? install_path : ::File.join(install_path, 'nssm.exe')
+  end
+end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -20,12 +20,13 @@ end
 action :install do
   if platform?('windows')
     install_nssm
+    nssm_bin = ::Nssm.binary_path node['nssm']['install_location']
 
     service_installed = service_installed?(new_resource.servicename)
 
     batch "Install #{new_resource.servicename} service" do
       code <<-EOH
-        nssm install "#{new_resource.servicename}" "#{new_resource.program}" #{new_resource.args}
+        #{nssm_bin} install "#{new_resource.servicename}" "#{new_resource.program}" #{new_resource.args}
       EOH
       not_if { service_installed }
     end
@@ -33,7 +34,7 @@ action :install do
     new_resource.params.map do |k, v|
       batch "Set parameter #{k} #{v}"  do
         code <<-EOH
-          nssm set "#{new_resource.servicename}" #{k} #{v}
+          #{nssm_bin} set "#{new_resource.servicename}" #{k} #{v}
         EOH
       end
     end unless service_installed
@@ -59,7 +60,7 @@ action :remove do
 
     batch "Remove service #{new_resource.servicename}" do
       code <<-EOH
-        nssm remove "#{new_resource.servicename}" confirm
+        #{nssm_bin} remove "#{new_resource.servicename}" confirm
       EOH
       only_if { service_installed }
     end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -32,7 +32,7 @@ action :install do
     end
 
     new_resource.params.map do |k, v|
-      batch "Set parameter #{k} #{v}"  do
+      batch "Set parameter #{k} #{v}" do
         code <<-EOH
           #{nssm_bin} set "#{new_resource.servicename}" #{k} #{v}
         EOH

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -19,7 +19,7 @@ end
 
 action :install do
   if platform?('windows')
-    install_nssm
+    install_nssm unless ::Nssm.installed?(node['nssm']['install_location'])
     nssm_bin = ::Nssm.binary_path node['nssm']['install_location']
 
     service_installed = service_installed?(new_resource.servicename)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,7 @@ if platform?('windows')
 
   batch 'copy_nssm' do
     code <<-EOH
-      xcopy #{Chef::Config[:file_cache_path].gsub('/', '\\')}\\#{basename}\\#{system}\\nssm.exe \
+      xcopy #{Chef::Config[:file_cache_path].tr('/', '\\')}\\#{basename}\\#{system}\\nssm.exe \
 "#{node['nssm']['install_location']}" /y
     EOH
     not_if { ::Nssm.installed? node['nssm']['install_location'] }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@ if platform?('windows')
       xcopy #{Chef::Config[:file_cache_path].gsub('/', '\\')}\\#{basename}\\#{system}\\nssm.exe \
 "#{node['nssm']['install_location']}" /y
     EOH
-    not_if { ::File.exist?('c:\\windows\\nssm.exe') }
+    not_if { ::Nssm.installed? node['nssm']['install_location'] }
   end
 else
   log 'NSSM can only be installed on Windows platforms!' do

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -15,7 +15,7 @@ describe 'nssm::default' do
 
     it 'copies nssm executable' do
       expect(chef_run).to run_batch('copy_nssm').with(
-        code: /xcopy .*\\nssm-2.24\\win64\\nssm.exe "%WINDIR%" \/y/)
+        code: %r{xcopy .*\\nssm-2.24\\win64\\nssm.exe "%WINDIR%" \/y/})
     end
   end
 

--- a/spec/unit/install_location_spec.rb
+++ b/spec/unit/install_location_spec.rb
@@ -9,6 +9,6 @@ describe 'nssm::default' do
 
   it 'copies nssm executable' do
     expect(chef_run).to run_batch('copy_nssm').with(
-      code: /xcopy .*\\nssm-2.24\\win64\\nssm.exe "c:\\somewhere" \/y/)
+      code: %r{xcopy .*\\nssm-2.24\\win64\\nssm.exe "c:\\somewhere" \/y})
   end
 end


### PR DESCRIPTION
The `install_location` attribute was used only for the copy part.
The provider was assuming that nssm is in the path and the recipe guard that it's in `c:\windows`

So I added 2 helpers to determine the binary path and whether it's present or not; then I leverage them in the provider and recipe.