### PR TITLE
Include default recipe in provide only if required

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -8,7 +8,7 @@ def execute_wmi_query(wmi_query)
 end
 
 def service_installed?(servicename)
-  !(execute_wmi_query("select * from Win32_Service where name = '#{servicename}'").nil?)
+  !execute_wmi_query("select * from Win32_Service where name = '#{servicename}'").nil?
 end
 
 def install_nssm

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -14,7 +14,7 @@ end
 def install_nssm
   recipe_eval do
     run_context.include_recipe 'nssm::default'
-  end
+  end unless run_context.loaded_recipe? 'nssm::default'
 end
 
 def nssm_exe


### PR DESCRIPTION
`recipe_eval` method converges at each run, updating the nssm resource.
This is not a good pattern & even worse when using `notify/subscribe`.

This PR fix this behavior by checking if the default recipe has been already included.

cc. @aboten