### PR TITLE
Fixes for Issue #12

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -9,7 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12
+  require_chef_omnibus: 12.7
 
 platforms:
   - name: windows-2012R2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,14 +3,14 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
-  require_chef_omnibus: 12.6
+  name: chef_zero
+  require_chef_omnibus: 12.7
 
-`platforms:
+platforms:
   - name: windows-2012r2
     driver:
       box: dhoer/windows-2012r2
-`
+
 suites:
   - name: nssm_test
     run_list:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
-gem 'chef', '>= 12.6'
+gem 'berkshelf', '~> 6.1'
+gem 'chef', '>= 12.7'
 gem 'chefspec'
 gem 'cookstyle'
 gem 'foodcritic'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   SSL_CERT_FILE: c:\projects\kitchen-machine\certs.pem
 
   matrix:
-    - ruby_version: "22"
+    - ruby_version: "23"
 
 clone_folder: c:\projects\kitchen-machine
 clone_depth: 1

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ description 'Installs/Configures NSSM'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/dhoer/chef-nssm'
 issues_url 'https://github.com/dhoer/chef-nssm/issues'
-version '3.0.0'
+version '4.0.0'
 
-chef_version '>= 12.6'
+chef_version '>= 12.7'
 
 supports 'windows'
 depends 'windows'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,7 @@ if platform?('windows')
 
   remote_file 'install nssm' do
     path "#{node['nssm']['install_location']}/nssm.exe"
-    source "file://#{system_file}"
+    source "file:///#{system_file}"
   end
 else
   log('NSSM can only be installed on Windows platforms!') { level :warn }


### PR DESCRIPTION
This commit does the following:

* Sets the minimum supported chef client version to 12.7
* Sets the windows cookbook version to 3.1
* Updates test kitchen to use chef_zero instead of chef_solo
* Fixes an issue in recipes/default.rb where the file URI needed 1 more slash.

This is intended to address Issue #12 