### PR TITLE
[WIP] Properly escape parameters in install action

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -70,9 +70,10 @@ action :install do
   )
 
   parameters.map do |k, v|
-    execute "Set parameter #{k} to #{v}" do
-      command "#{nssm_exe} set \"#{new_resource.servicename}\" #{k} \"#{v.to_s.gsub('"', '""').strip}\""
-      not_if "#{nssm_exe} get \"#{new_resource.servicename}\" #{k} | grep -F -- \"#{v.to_s.gsub('"', '""').strip}\""
+    value = v.to_s.gsub('"', '^"').strip
+    execute "Set parameter #{k} to #{value}" do
+      command "#{nssm_exe} set \"#{new_resource.servicename}\" #{k} \"#{value}\""
+      not_if "#{nssm_exe} get \"#{new_resource.servicename}\" #{k} | grep -F -- \"#{value}\""
     end
   end
 


### PR DESCRIPTION
This has been done for install_if_missing but not for the install action.
This could be considered as a 'breaking change'. But it fixes a bit the
behavior following #7.

*Cc.* @aboten