### PR TITLE
Fix the "start service on install" behavior

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -25,8 +25,8 @@ end
 action :install do
   install_nssm
 
-  # Include action_start's resources to allow notification
-  action_start
+  # Declare the service for start notification
+  service new_resource.servicename
 
   execute "Install #{new_resource.servicename} service" do
     command ::NSSM.command(new_resource.nssm_binary, :install, new_resource.servicename, new_resource.program, new_resource.args)
@@ -53,8 +53,8 @@ action :install_if_missing do
 end
 
 action :remove do
-  # Ensure service is stopped before removing it
-  action_stop
+  # Declare the service for stop notification
+  service new_resource.servicename
 
   execute "Remove service #{new_resource.servicename}" do
     command ::NSSM.command(new_resource.nssm_binary, :remove, new_resource.servicename, :confirm)

--- a/spec/unit/install_service_spec.rb
+++ b/spec/unit/install_service_spec.rb
@@ -155,7 +155,7 @@ describe 'nssm_test::install_service' do
       end
 
       it 'starts service' do
-        expect(chef_run).to start_service('service name')
+        expect(chef_run).not_to start_service('service name')
       end
     end
 


### PR DESCRIPTION
Following #22 the kitchen tests were failing with following error:
>resource execute[Install service name service] is configured to notify resource service[service name] with action start, but service[service name] cannot be found in the resource collection. execute[Install service name service] is defined in ...

Including other action does not seem to work for notif with Chef 12.7. Instanciate and notify dedicated resource when start/stop is required is working better.

*Cc.* @aboten, @dhoer