### PR TITLE
Stop using non-documented argument for nssm dump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ gem 'foodcritic'
 
 group :integration do
   gem 'kitchen-vagrant'
-  gem 'test-kitchen'
+  gem 'test-kitchen', '~> 1.16.0'
   gem 'winrm-fs'
 end


### PR DESCRIPTION
As described in #34, using a MARKER argument creates an Error in
the event log. The MARKER is not really neaded it's easy to parse
the output using simple Regexp.

Fix #34