### PR TITLE
Use archive_file, drop windows depends - Chef 15+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NSSM CHANGELOG
 
+## 5.0.0 2021-07-02
+* [Wade Peacock] - Drop Windows Depends
+  - Switch to `archive_file` from `windows_zipfile`
+  - Minimum Chef Version to >= 15
+  - Cookstyle - Fix all issues
+
 ## 4.0.1 2018-07-25
 
 - Remote file is now before notification friendly (fixes #33)
@@ -8,7 +14,7 @@
 
 ## 4.0.0 2017-08-02
 
-- Convert default recipe to custom resource with idempotence 
+- Convert default recipe to custom resource with idempotence
 - Allow install of nssm to be optional
 - Properly escape parameters in install action (custom quoting should be removed)
 - Make start service idempotent

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 gem 'berkshelf'
 gem 'chef', '>= 12.14.89'
 gem 'chefspec', '>= 7.1.0'
+gem 'cookstyle'
 gem 'foodcritic'
-gem 'rubocop', '= 0.58.2'
 
 group :integration do
   gem 'kitchen-vagrant'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'cookstyle'
 require 'foodcritic'
 require 'rubocop/rake_task'
 require 'rspec/core/rake_task'
@@ -12,4 +13,4 @@ RuboCop::RakeTask.new do |task|
 end
 FoodCritic::Rake::LintTask.new(:foodcritic)
 
-task default: %i[foodcritic rubocop spec]
+task default: %i(foodcritic rubocop spec)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,16 +1,12 @@
-# frozen_string_literal: true
-
 name 'nssm'
 maintainer 'Dennis Hoer'
 maintainer_email 'dennis.hoer@gmail.com'
 license 'MIT'
 description 'Installs/Configures NSSM'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/criteo-cookbooks/nssm'
 issues_url 'https://github.com/criteo-cookbooks/nssm/issues'
-version '4.0.1'
+version '5.0.0'
 
-chef_version '>= 12.7'
+chef_version '>= 15.0'
 
 supports 'windows'
-depends 'windows'

--- a/resources/install_noop.rb
+++ b/resources/install_noop.rb
@@ -1,7 +1,8 @@
 provides :nssm_install
+unified_mode true
 
-property :source, String, identity: true, name_property: true
-property :sha256, String, required: true
+property :source, kind_of: String, identity: true, name_property: true
+property :sha256, kind_of: String, required: true
 
 default_action :install
 
@@ -10,7 +11,4 @@ action :install do
 end
 
 action_class do
-  def whyrun_supported?
-    true
-  end
 end

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -1,13 +1,14 @@
 provides :nssm_service, platform: 'windows'
+unified_mode true
 # TODO: migrate to nssm_service with a breaking change notice
 provides :nssm, platform: 'windows'
 
-property :servicename, String, name_property: true
-property :program, String, required: true
-property :args, String
-property :parameters, Hash, default: lazy { ::Mash.new }
-property :nssm_binary, [String, NilClass], default: lazy { ::NSSM.binary_path node }
-property :start, [TrueClass, FalseClass], default: true
+property :servicename, kind_of: String, name_property: true
+property :program, kind_of: String, required: true
+property :args, kind_of: String
+property :parameters, kind_of: Hash, default: lazy { ::Mash.new }
+property :nssm_binary, kind_of: String, default: lazy { ::NSSM.binary_path node }
+property :start, kind_of: [TrueClass, FalseClass], default: true
 # TODO: add start as default action with a breaking change
 default_action :install
 
@@ -32,6 +33,11 @@ action :install do
   # Declare the service for start notification
   service new_resource.servicename
 
+  # Some NSSM parameters have no meaningful default, list them here to prevent errors on reset command
+  params_no_default = ' Application AppDirectory DisplayName ObjectName Start Type AppEvents '
+  needs_sub_param = ' AppExit '
+  sub_param_defaults = { 'AppExit' => 'Default Restart' }
+
   execute "Install #{new_resource.servicename} service" do
     command ::NSSM.command(new_resource.nssm_binary, :install, new_resource.servicename, new_resource.program, new_resource.args)
     only_if { current_resource.nil? }
@@ -46,24 +52,30 @@ action :install do
   params = new_resource.parameters.merge(Application: new_resource.program)
   params = params.merge(AppParameters: new_resource.args) unless new_resource.args.nil?
   params.each do |key, value|
+    value = "Default #{value}" if needs_sub_param.include?(key.to_s) && (value !~ /^Default /i)
     execute "Set parameter #{key} to #{value}" do
       command ::NSSM.command(new_resource.nssm_binary, :set, new_resource.servicename, key, value)
-      not_if { current_resource && current_resource.parameters[key] == ::NSSM.prepare_parameter(value) }
+      not_if { current_resource && current_resource.parameters[key.to_s] == ::NSSM.prepare_for_compare(key, value) }
+      # not_if { current_resource && current_resource.parameters[key] == ::NSSM.prepare_parameter(value) }
     end
   end
 
-  # Some NSSM parameters have no meaningful default, list them here to prevent errors on reset command
-  params_no_default = ' Application AppDirectory DisplayName ObjectName Start Type '
-  needs_sub_param = ' AppExit '
-
-  current_resource.parameters.each do |key, _value|
-    execute "Reset parameter #{key} to default" do
-      command ::NSSM.command(new_resource.nssm_binary, :reset, new_resource.servicename, key)
-      not_if { params.key?(key.to_sym) || params_no_default.include?(key) || needs_sub_param.include?(key) }
-    end
-    execute "Reset parameter #{key} to default with default subparameter" do
-      command ::NSSM.command(new_resource.nssm_binary, :reset, new_resource.servicename, key, 'default')
-      only_if { needs_sub_param.include?(key) }
+  current_resource.parameters.each do |key, value|
+    # Skip if user defined value is supplied to resource
+    next if params.key?(key.to_sym) | params.key?(key.to_s)
+    # Skip if parameter has no default
+    next if params_no_default.include?(key)
+    case needs_sub_param.include?(key)
+    when false
+      execute "Reset parameter #{key} to default" do
+        command ::NSSM.command(new_resource.nssm_binary, :reset, new_resource.servicename, key)
+      end
+    when true
+      execute "Reset parameter #{key} to default with default subparameter" do
+        command ::NSSM.command(new_resource.nssm_binary, :reset, new_resource.servicename, key, 'default')
+        # not_if it is already set to it's default value
+        not_if { sub_param_defaults.key?(key) && sub_param_defaults[key] == ::NSSM.prepare_for_compare(key, value) }
+      end
     end
   end unless current_resource.nil?
 end
@@ -98,7 +110,4 @@ action :stop do
 end
 
 action_class do
-  def whyrun_supported?
-    true
-  end
 end

--- a/resources/service_noop.rb
+++ b/resources/service_noop.rb
@@ -1,13 +1,14 @@
 provides :nssm_service
+unified_mode true
 provides :nssm # TODO: migrate to nssm_service with a breaking change notice
 
-property :servicename, String, identity: true, name_property: true
-property :program, String, required: true
-property :args, String
-property :parameters, Hash, default: lazy { ::Mash.new }
-property :nssm_binary, [String, NilClass], default: nil
+property :servicename, kind_of: String, identity: true, name_property: true
+property :program, kind_of: String, required: true
+property :args, kind_of: String
+property :parameters, kind_of: Hash, default: lazy { ::Mash.new }
+property :nssm_binary, kind_of: String, default: nil
 # TODO: remove this
-property :start, [TrueClass, FalseClass], default: true
+property :start, kind_of: [TrueClass, FalseClass], default: true
 
 action :install do
   ::Chef::Log.warn('NSSM service can only be installed on Windows platforms!')
@@ -30,7 +31,4 @@ action :stop do
 end
 
 action_class do
-  def whyrun_supported?
-    true
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,8 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 
 CACHE = Chef::Config[:file_cache_path]
-VERSION = '2.24-94-g9c88bc1'.freeze
-SHA256 = '0bbe25025b69ebd8ab263ec4b443513d28a0d072e5fdd9b5cdb327359a27f96e'.freeze
-DRIVE = RUBY_PLATFORM =~ /mswin|mingw32|windows/ ? 'C:' : ''
+VERSION = '2.24-94-g9c88bc1'
+SHA256 = '0bbe25025b69ebd8ab263ec4b443513d28a0d072e5fdd9b5cdb327359a27f96e'
 
 def stub_win32_service_class
   return if defined?(::Win32::Service) && ::Win32::Service.is_a?(::RSpec::Mocks::Double)
@@ -16,7 +15,7 @@ end
 
 def stub_win32_service_method(method_name, service_name, *results)
   stub_win32_service_class
-  allow(::Win32::Service).to receive(method_name).with(service_name).and_return(*results)
+  expect(::Win32::Service).to receive(method_name).with(service_name).and_return(*results)
 end
 
 def stub_shellout(cmd, options = {})

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -27,8 +27,6 @@ describe 'nssm::default' do
     end
 
     it 'install nssm' do
-      allow(::File).to receive(:exist?).and_call_original
-      expect(::File).to receive(:exist?).with("#{CACHE}/nssm-2.24-94-g9c88bc1/win64/nssm.exe").and_return true
       expect(chef_run).to create_remote_file('install nssm').with(
         path: "C:\\tmp\\nssm-#{VERSION}.exe",
         source: "file:///#{CACHE}/nssm-2.24-94-g9c88bc1/win64/nssm.exe"

--- a/spec/unit/install_service_spec.rb
+++ b/spec/unit/install_service_spec.rb
@@ -5,71 +5,71 @@ require 'spec_helper'
 describe 'nssm_test::install_service' do
   context 'windows' do
     let(:cache_dir) { 'C:/chef/cache' }
-    let(:service_exist) { false }
-    let(:binary_path) { "#{DRIVE}\\nssm-#{VERSION}.exe" }
     let(:chef_run) do
       ChefSpec::SoloRunner.new(
         file_cache_path: cache_dir,
         platform: 'windows',
         version: '2008R2',
         step_into: ['nssm']
-      ) do
-        stub_win32_service_method(:exists?, 'service name', service_exist)
-        stub_win32_service_method(:config_info, 'service name', double('config', binary_path_name: binary_path))
-      end.converge(described_recipe)
+      ).converge(described_recipe)
     end
 
     context 'when the service is not yet installed' do
+      before do
+        stub_win32_service_method :exists?, 'service name', false
+      end
+
       it 'installs selenium' do
         expect(chef_run).to create_remote_file(File.join(cache_dir, 'selenium-server-standalone-2.53.0.jar'))
       end
 
       it 'calls nssm install resource' do
         expect(chef_run).to install_nssm('service name').with(
-          program: "#{DRIVE}\\java\\bin\\java.exe",
+          program: 'C:\java\bin\java.exe',
           args: %(-jar C:\\chef\\cache\\selenium-server-standalone-2.53.0.jar)
         )
       end
 
       it 'executes command to install service' do
         expect(chef_run).to run_execute('Install service name service').with(
-          command: /nssm-#{VERSION}.exe install "service name" #{DRIVE}\\java\\bin\\java.exe -jar C:\\chef\\cache\\selenium-server-standalone-2.53.0.jar/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe install "service name" C:\\java\\bin\\java.exe) \
+            ' -jar C:\\chef\\cache\\selenium-server-standalone-2.53.0.jar'
         )
       end
 
       it 'sets application' do
-        expect(chef_run).to run_execute("Set parameter Application to #{DRIVE}\\java\\bin\\java.exe").with(
-          command: /nssm-#{VERSION}.exe set "service name" Application #{DRIVE}\\java\\bin\\java.exe/
+        expect(chef_run).to run_execute('Set parameter Application to C:\java\bin\java.exe').with(
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" Application C:\\java\\bin\\java.exe)
         )
       end
 
       it 'sets args' do
         expect(chef_run).to run_execute('Set parameter AppParameters to -jar C:\chef\cache\selenium-server-standalone-2.53.0.jar').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppParameters -jar C:\\chef\\cache\\selenium-server-standalone-2.53.0.jar/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppParameters -jar C:\\chef\\cache\\selenium-server-standalone-2.53.0.jar)
         )
       end
 
       it 'sets start directory parameters' do
         expect(chef_run).to run_execute('Set parameter AppDirectory to C:\chef\cache').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppDirectory C:\\chef\\cache/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppDirectory C:\\chef\\cache)
         )
       end
 
       it 'sets stdout log' do
         expect(chef_run).to run_execute('Set parameter AppStdout to C:\chef\cache\service.log').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppStdout C:\\chef\\cache\\service.log/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppStdout C:\\chef\\cache\\service.log)
         )
       end
 
       it 'sets stderr log' do
         expect(chef_run).to run_execute('Set parameter AppStderr to C:\chef\cache\error.log').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppStderr C:\\chef\\cache\\error.log/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppStderr C:\\chef\\cache\\error.log)
         )
       end
 
       it 'sets rotate files' do
         expect(chef_run).to run_execute('Set parameter AppRotateFiles to 1').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppRotateFiles 1/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppRotateFiles 1)
         )
       end
 
@@ -80,34 +80,39 @@ describe 'nssm_test::install_service' do
 
     context 'when the service is already installed' do
       before do
-        stub_shellout '\\nssm-2.24-94-g9c88bc1.exe dump "service name"', stdout: <<-STDOUT
-          set service name Application xxx
-          set service name AppDirectory C:\\chef\\cache
-          set service name AppStdout C:\\chef\\cache\\service.log
-          set service name AppStderr C:\\chef\\cache\\error.log
-          set service name AppRotateFiles 1
-        STDOUT
+        stub_win32_service_method :exists?, 'service name', true
+        stub_win32_service_method :config_info, 'service name', double('config', binary_path_name: 'c:\tmp\nssm.exe')
       end
-      let(:service_exist) { true }
 
       it 'does not execute command to install service' do
-        expect(chef_run).to_not run_execute('Install service name service')
+        expect(chef_run).to_not run_execute('Install service name service').with(
+          command: %(C:\tmp\\nssm-#{VERSION}.exe install "service name" "C:\\java\\bin\\java.exe") \
+            ' -jar "C:\\chef\\cache\\selenium-server-standalone-2.53.0.jar"'
+        )
       end
 
       it 'does not set start directory parameters' do
-        expect(chef_run).to_not run_execute('Set parameter AppDirectory to C:\\chef\\cache')
+        expect(chef_run).to_not run_execute('Set parameter AppDirectory to C:\\chef\\cache').with(
+          command: %(C:\tmp\\nssm-#{VERSION}.exe set "service name" AppDirectory C:\\chef\\cache)
+        )
       end
 
       it 'does not set stdout log' do
-        expect(chef_run).to_not run_execute('Set parameter AppStdout to C:\\chef\\cache\\service.log')
+        expect(chef_run).to_not run_execute('Set parameter AppStdout to C:\\chef\\cache\\service.log').with(
+          command: %(C:\tmp\\nssm-#{VERSION}.exe set "service name" AppStdout C:\\chef\\cache\\service.log)
+        )
       end
 
       it 'does not set stderr log' do
-        expect(chef_run).to_not run_execute('Set parameter AppStderr to C:\\chef\\cache\\error.log')
+        expect(chef_run).to_not run_execute('Set parameter AppStderr to C:\\chef\\cache\\error.log').with(
+          command: %(C:\tmp\\nssm-#{VERSION}.exe set "service name" AppStderr C:\\chef\\cache\\error.log)
+        )
       end
 
       it 'does not set rotate files' do
-        expect(chef_run).to_not run_execute('Set parameter AppRotateFiles to 1')
+        expect(chef_run).to_not run_execute('Set parameter AppRotateFiles to 1').with(
+          command: %(C:\tmp\\nssm-#{VERSION}.exe set "service name" AppRotateFiles 1)
+        )
       end
 
       it 'does not notifie the service' do
@@ -116,8 +121,10 @@ describe 'nssm_test::install_service' do
     end
 
     describe 'when the service is installed with incorrect parameters' do
-      let(:service_exist) { true }
-      let(:binary_path) { 'c:\tmp\nssm.exe' }
+      before do
+        stub_win32_service_method :exists?, 'service name', true
+        stub_win32_service_method :config_info, 'service name', double('config', binary_path_name: 'c:\tmp\nssm.exe')
+      end
 
       it 'installs selenium' do
         expect(chef_run).to create_remote_file(File.join(cache_dir, 'selenium-server-standalone-2.53.0.jar'))
@@ -125,25 +132,25 @@ describe 'nssm_test::install_service' do
 
       it 'sets start directory parameters' do
         expect(chef_run).to run_execute('Set parameter AppDirectory to C:\\chef\\cache').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppDirectory C:\\chef\\cache/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppDirectory C:\\chef\\cache)
         )
       end
 
       it 'sets stdout log' do
         expect(chef_run).to run_execute('Set parameter AppStdout to C:\\chef\\cache\\service.log').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppStdout C:\\chef\\cache\\service.log/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppStdout C:\\chef\\cache\\service.log)
         )
       end
 
       it 'sets stderr log' do
         expect(chef_run).to run_execute('Set parameter AppStderr to C:\\chef\\cache\\error.log').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppStderr C:\\chef\\cache\\error.log/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppStderr C:\\chef\\cache\\error.log)
         )
       end
 
       it 'sets rotate files' do
         expect(chef_run).to run_execute('Set parameter AppRotateFiles to 1').with(
-          command: /nssm-#{VERSION}.exe set "service name" AppRotateFiles 1/
+          command: %(C:\\tmp\\nssm-#{VERSION}.exe set "service name" AppRotateFiles 1)
         )
       end
 
@@ -156,7 +163,7 @@ describe 'nssm_test::install_service' do
       let(:cache_dir) { '/var/chef/cache' }
       let(:chef_run) do
         ChefSpec::SoloRunner.new(
-          file_cache_path: cache_dir, platform: 'centos', version: '7.3.1611', step_into: ['nssm']
+          file_cache_path: cache_dir, platform: 'centos', version: '7', step_into: ['nssm']
         ).converge(described_recipe)
       end
 

--- a/test/fixtures/cookbooks/nssm_test/metadata.rb
+++ b/test/fixtures/cookbooks/nssm_test/metadata.rb
@@ -5,7 +5,6 @@ maintainer 'Dennis Hoer'
 maintainer_email 'dennis.hoer@gmail.com'
 license 'All rights reserved'
 description 'Installs/Configures nssm_test'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 
 depends 'nssm'


### PR DESCRIPTION
```
5.0.0 2021-07-02
* [Wade Peacock] - Drop Windows Depends
  - Switch to `archive_file` from `windows_zipfile`
  - Minimum Chef Version to >= 15
  - Cookstyle - Fix all issues
```

Attempts to get test cookbook working were fruitless due to java_se
download issue.

We are actively using this version